### PR TITLE
Add plan_execute endpoint with planning model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ forecasting/
 | `/preview_sql` | POST | Preview SQL execution without applying changes |
 | `/apply_sql` | POST | Execute approved SQL transformations |
 | `/agent` | POST | Interact with the LangChain agent |
+| `/plan_execute` | POST | Plan with DeepSeek and execute with Llama |
 | `/voice` | POST | Voice commands via Whisper and agent |
 | `/load_table` | POST | Upload CSV data into a table (append or replace) |
 | `/data_quality` | GET | Check for unmatched or incomplete data |

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from db import (
 # Import LLM service
 from services.llm_service import llm_service, LLMRequest
 from services.agent_service import agent_service, AgentRequest
+from services.plan_execute_service import plan_execute_service
 from services.whisper_service import whisper_service
 from utils.data_loader import load_csv_to_table
 from utils.data_quality import get_data_quality_issues
@@ -119,6 +120,17 @@ async def agent_endpoint(request: ChatRequest):
         agent_request = AgentRequest(message=request.message, context=request.context)
         result = await agent_service.run(agent_request)
         return ForecastResponse(status="success", data={"response": result}, message="Agent response generated")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/plan_execute", response_model=ForecastResponse)
+async def plan_execute_endpoint(request: ChatRequest):
+    """Plan with DeepSeek and execute with the Llama agent"""
+    try:
+        agent_request = AgentRequest(message=request.message, context=request.context)
+        result = await plan_execute_service.run(agent_request)
+        return ForecastResponse(status="success", data=result, message="Plan and execution completed")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,1 +1,3 @@
-# Business logic, transformers, and recalculation services 
+# Business logic, transformers, and recalculation services
+
+from .plan_execute_service import plan_execute_service

--- a/app/services/plan_execute_service.py
+++ b/app/services/plan_execute_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import httpx
+from typing import Dict, Any, Optional, List
+
+from .agent_service import AgentService, AgentRequest
+
+
+class PlanAndExecuteService:
+    """Service that plans with one model and executes with another."""
+
+    def __init__(
+        self,
+        agent_service: AgentService,
+        ollama_url: str = "http://ollama:11434",
+        planning_model: str = "deepseek:r1",
+    ) -> None:
+        self.agent_service = agent_service
+        self.ollama_url = ollama_url
+        self.planning_model = planning_model
+
+    async def _call_ollama(
+        self, model: str, prompt: str, temperature: float = 0.2, max_tokens: int = 500
+    ) -> str:
+        """Call the Ollama API with the given model and prompt."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            payload = {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"temperature": temperature, "num_predict": max_tokens},
+            }
+            response = await client.post(f"{self.ollama_url}/api/generate", json=payload)
+            if response.status_code != 200:
+                raise Exception(f"Ollama API error: {response.status_code} - {response.text}")
+            result = response.json()
+            return result.get("response", "")
+
+    async def _generate_plan(self, message: str) -> List[str]:
+        """Generate a numbered plan for the given message."""
+        prompt = (
+            "You are a planning assistant. Break down the following request into a"
+            " concise numbered list of steps.\nRequest:" + message + "\nPlan:"
+        )
+        plan_text = await self._call_ollama(self.planning_model, prompt)
+        steps = [step.strip("- ") for step in plan_text.split("\n") if step.strip()]
+        return steps
+
+    async def run(self, request: AgentRequest) -> Dict[str, Any]:
+        """Plan with DeepSeek and execute each step with the Llama agent."""
+        steps = await self._generate_plan(request.message)
+        results = []
+        for step in steps:
+            step_request = AgentRequest(message=step, context=request.context)
+            res = await self.agent_service.run(step_request)
+            results.append({"step": step, "result": res})
+        return {"plan": steps, "results": results}
+
+
+# Global instance used by FastAPI
+from .agent_service import agent_service
+
+plan_execute_service = PlanAndExecuteService(agent_service)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,15 @@ def test_app(test_db_manager):
             data={"response": f"Agent processed: {request.message}"},
             message="Agent response generated"
         )
+    @test_app.post("/plan_execute", response_model=ForecastResponse)
+    async def plan_execute_endpoint(request: ChatRequest):
+        """Plan and execute endpoint for testing"""
+        return ForecastResponse(
+            status="success",
+            data={"plan": ["step 1"], "results": [{"step": "step 1", "result": "done"}]},
+            message="Plan executed",
+        )
+
  
     @test_app.post("/voice", response_model=ForecastResponse)
     async def voice_endpoint(audio: UploadFile = File(...), session_id: Optional[str] = None):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -111,6 +111,16 @@ class TestAPIEndpoints:
         assert data["status"] == "success"
         assert "response" in data["data"]
 
+    def test_plan_execute_endpoint(self, client: TestClient):
+        """Test the plan_execute endpoint"""
+        req = {"message": "Increase July forecast by 15%"}
+        response = client.post("/plan_execute", json=req)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "plan" in data["data"]
+        assert "results" in data["data"]
+
     def test_voice_endpoint(self, client: TestClient):
         """Test the voice command endpoint"""
         response = client.post("/voice", files={"audio": ("test.wav", b"dummy", "audio/wav")})


### PR DESCRIPTION
## Summary
- introduce `PlanAndExecuteService` for planning with DeepSeek and executing with the existing agent
- expose new `/plan_execute` endpoint
- document the endpoint
- add stubbed endpoint in test app and new API test

## Testing
- `pip install -r app/requirements.txt`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6873f687ad8883308096e8ed73511cfb